### PR TITLE
Add LICENSE and README.md to setuptools distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
Previously, any tarball produced by 'python setup.py sdist'
didn't comply with the license agreement in the LICENSE file
since that file wasn't included. That's addressed with this
addition to MANIFEST.in.
